### PR TITLE
Actual brightness limit is 100, no need to scale

### DIFF
--- a/lib/devices/gateway.js
+++ b/lib/devices/gateway.js
@@ -92,7 +92,7 @@ class Gateway extends Device {
 						green: 0xff & (rgba >> 8),
 						blue: 0xff & rgba
 					});
-					this.setProperty('brightness', Math.round((0xff & (rgba >> 24)) / 255 * 100));
+					this.setProperty('brightness', Math.round((0xff & (rgba >> 24)) ));
 					break;
 				}
 			}
@@ -179,7 +179,7 @@ class Gateway extends Device {
 			}
 
 
-			const a = Math.max(0, Math.min(255, Math.round(this.property('brightness') / 100 * 255)));
+			const a = Math.max(0, Math.min(255, Math.round(this.property('brightness'))));
 			const rgb = a << 24 | (color.red << 16) | (color.green << 8) | color.blue;
 			return this.call('set_rgb', [ rgb >>> 0 ]);//, { refresh: [ 'rgb' ] });
 		};
@@ -190,7 +190,7 @@ class Gateway extends Device {
 
 		this.capabilities.push('brightness');
 		this.setBrightness = function(brightness) {
-			const a = Math.max(0, Math.min(255, Math.round(brightness / 100 * 255)));
+			const a = Math.max(0, Math.min(255, Math.round(brightness)));
 			const color = this.property('rgb');
 			const rgb = a << 24 | (color.red << 16) | (color.green << 8) | color.blue;
 			return this.call('set_rgb', [ rgb >>> 0 ]);//, { refresh: [ 'rgb' ] });


### PR DESCRIPTION
From my experiments with gateway, actual hardware limits for brightness are [0..100]
So there is no need to scale brightness up to [0..255]