### PR TITLE
Adding support for lumi.ctrl_ln1 and lumi.ctrl_ln2

### DIFF
--- a/lib/devices/gateway.js
+++ b/lib/devices/gateway.js
@@ -29,7 +29,12 @@ const types = {
 	// Temperature and Humidity sensor
 	10: require('./gateway/sensor_ht'),
 
-	11: require('./gateway/plug')
+	11: require('./gateway/plug'),
+
+	// Light switch (live+neutral wire version) with one channel
+	20: require('./gateway/ctrl_ln1'),
+	// Light switch (live+neutral wire version) with two channels
+	21: require('./gateway/ctrl_ln2')
 }
 /**
  * Generate a key for use with the local developer API. This does not generate

--- a/lib/devices/gateway/ctrl_ln1.js
+++ b/lib/devices/gateway/ctrl_ln1.js
@@ -1,0 +1,30 @@
+'use strict';
+
+
+
+const SubDevice = require('./subdevice');
+
+const PowerChannels = require('../capabilities/power-channels');
+
+/**
+ * Single-channel L-N version of light switch.
+ */
+class CtrlLN1 extends SubDevice {
+	constructor(parent, info) {
+		super(parent, info);
+
+		this.type = 'power-switch';
+		this.model = 'lumi.ctrl_ln1';
+
+		this.defineProperty('channel_0', {
+			name: 'powerChannel0',
+			mapper: v => v == 'on'
+		});
+		PowerChannels.extend(this, {
+			channels: [ 0 ],
+			set: (channel, power) => this.call('toggle_ctrl_neutral', [ 'neutral_' + channel, power ? 'on' : 'off' ])
+		});
+	}
+}
+
+module.exports = CtrlLN1;

--- a/lib/devices/gateway/ctrl_ln2.js
+++ b/lib/devices/gateway/ctrl_ln2.js
@@ -1,0 +1,34 @@
+'use strict';
+
+
+
+const SubDevice = require('./subdevice');
+
+const PowerChannels = require('../capabilities/power-channels');
+
+/**
+ * Dual-channel L-N version of light switch.
+ */
+class CtrlLN2 extends SubDevice {
+	constructor(parent, info) {
+		super(parent, info);
+
+		this.type = 'power-switch';
+		this.model = 'lumi.ctrl_ln2';
+
+		this.defineProperty('channel_0', {
+			name: 'powerChannel0',
+			mapper: v => v == 'on'
+		});
+		this.defineProperty('channel_1', {
+			name: 'powerChannel1',
+			mapper: v => v == 'on'
+		});
+		PowerChannels.extend(this, {
+			channels: [ 0, 1 ],
+			set: (channel, power) => this.call('toggle_ctrl_neutral', [ 'neutral_' + channel, power ? 'on' : 'off' ])
+		});
+	}
+}
+
+module.exports = CtrlLN2;


### PR DESCRIPTION
Tested and works.
They have the same api as `lumi.ctrl_neutralN`

