### PR TITLE
Add function controlling music for gateway

### DIFF
--- a/docs/devices/gateway.md
+++ b/docs/devices/gateway.md
@@ -39,3 +39,11 @@ Tell the gateway that you no longer want to add a new device.
 ### `device.removeDevice(id)`
 
 Remove a device from the gateway using its identifier.
+
+### `device.playMusic(id, volume)`
+
+Start playing music using its identifier at specific volume.
+
+### `device.stopMusic()`
+
+Stop playing music.

--- a/lib/devices/gateway.js
+++ b/lib/devices/gateway.js
@@ -337,6 +337,21 @@ class Gateway extends Device {
 			.then(() => undefined);
 	}
 
+	/**
+	 * Start playing music at specific volume using id of the music
+	 */
+	playMusic(id, volume) {
+		return this.call('play_music_new', [id.toString(), volume])
+			.then(Device.checkOk)
+			.then(() => undefined);
+	}
+
+	stopMusic() {
+		return this.call('set_sound_playing', ['off'])
+			.then(Device.checkOk)
+			.then(() => undefined);
+	}
+
 }
 
 const MULTICAST_ADDRESS = '224.0.0.50';


### PR DESCRIPTION
This PR adds two function, `playMusic(id, volume)` and `stopMusic()` for class `Gateway` and update docs.

Gateway uses `play_music_new` to play musics, which takes two argument: `id: string` and `volume: number`.