### PR TITLE
Adding support for Aqara Temperature/Humidity/Pressure sensor

### DIFF
--- a/docs/devices/sensor.md
+++ b/docs/devices/sensor.md
@@ -60,3 +60,15 @@ For when the device supports measuring illuminance in Lux.
 ### `device.illuminance: number`
 
 Get the current illuminance in Lux
+
+## Capability: `pressure`
+
+For when the device supports measuring the atmospheric pressure.
+
+### Properties
+
+* `pressure` - Atmospheric pressure
+
+### `device.pressure: number`
+
+Get the current atmospheric pressure in kPa

--- a/lib/devices/gateway.js
+++ b/lib/devices/gateway.js
@@ -31,6 +31,8 @@ const types = {
 
 	11: require('./gateway/plug'),
 
+	// Aqara Temperature/Humidity/Pressure sensor
+	19: require('./gateway/weather'),
 	// Light switch (live+neutral wire version) with one channel
 	20: require('./gateway/ctrl_ln1'),
 	// Light switch (live+neutral wire version) with two channels

--- a/lib/devices/gateway/weather.js
+++ b/lib/devices/gateway/weather.js
@@ -1,0 +1,25 @@
+'use strict';
+
+
+const SubDevice = require('./subdevice');
+const Sensor = require('../capabilities/sensor');
+
+class WeatherSensor extends SubDevice {
+	constructor(parent, info) {
+		super(parent, info);
+
+		this.type = 'sensor';
+		this.model = 'lumi.weather';
+
+		this.defineProperty('temperature', v => v / 100.0);
+		Sensor.extend(this, { name: 'temperature' });
+
+		this.defineProperty('humidity', v => v / 100.0);
+		Sensor.extend(this, { name: 'humidity' });
+
+		this.defineProperty('pressure', v => v / 1000.0);
+		Sensor.extend(this, { name: 'pressure' });
+	}
+}
+
+module.exports = WeatherSensor;


### PR DESCRIPTION
tested.

```node
> weatherSensor.type
'sensor'
> weatherSensor.model
'lumi.weather'
> weatherSensor.properties
{ temperature: 35.53, humidity: 46.74, pressure: 100.2 }
> weatherSensor.pressure
100.2
```