### PR TITLE
Add support for Xiaomi Philips Ball Lamp

### DIFF
--- a/lib/devices/philips-light-bulb.js
+++ b/lib/devices/philips-light-bulb.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const Device = require('../device');
+
+const Power = require('./capabilities/power');
+
+class BallLamp extends Device {
+	static get TYPE() {
+		return 'light'
+	}
+
+	constructor(options) {
+		super(options);
+
+		this.type = BallLamp.TYPE;
+
+		this.defineProperty('power', {
+			name: 'power',
+			mapper: v => v === 'on'
+		});
+		Power.extend(this, {
+			set: power => this.call('set_power', [power ? 'on' : 'off'], {
+				refresh: true
+			})
+
+		});
+
+		this.defineProperty('bright', {
+			name: 'brightness',
+			mapper: parseInt
+		});
+		this.capabilities.push('brightness');
+
+		this.defineProperty('cct', {
+			name: 'colortemp',
+			mapper: parseInt
+		});
+		this.capabilities.push('colortemp');
+	}
+
+	// Get brightness from 1 to 100
+	get brightness() {
+		return this.property('brightness');
+	}
+
+	// Get color temp from 1 (lowest/warmest) to 100
+	get colortemp() {
+		return this.property('colortemp');
+	}
+
+	// Set brightness
+	setBrightness(brightness, options = {}) {
+		return this.call('set_bright', [brightness, options], {
+			refresh: true
+		}).then(Device.checkOk);
+	}
+
+	// Set color temp
+	setColortemp(brightness, options = {}) {
+		return this.call('set_cct', [brightness, options], {
+			refresh: true
+		}).then(Device.checkOk);
+	}
+
+}
+
+module.exports = BallLamp;

--- a/lib/devices/philips-light-bulb.js
+++ b/lib/devices/philips-light-bulb.js
@@ -32,10 +32,10 @@ class BallLamp extends Device {
 		this.capabilities.push('brightness');
 
 		this.defineProperty('cct', {
-			name: 'colortemp',
+			name: 'colorTemperature',
 			mapper: parseInt
 		});
-		this.capabilities.push('colortemp');
+		this.capabilities.push('color:temperature');
 	}
 
 	// Get brightness from 1 to 100
@@ -44,8 +44,8 @@ class BallLamp extends Device {
 	}
 
 	// Get color temp from 1 (lowest/warmest) to 100
-	get colortemp() {
-		return this.property('colortemp');
+	get colorTemperature() {
+		return this.property('colorTemperature');
 	}
 
 	// Set brightness
@@ -56,7 +56,7 @@ class BallLamp extends Device {
 	}
 
 	// Set color temp
-	setColortemp(brightness, options = {}) {
+	setColorTemperature(brightness, options = {}) {
 		return this.call('set_cct', [brightness, options], {
 			refresh: true
 		}).then(Device.checkOk);

--- a/lib/models.js
+++ b/lib/models.js
@@ -38,6 +38,6 @@ module.exports = {
 	'yeelink.light.lamp1': require('./devices/yeelight.lamp'),
 	'yeelink.light.mono1': require('./devices/yeelight.mono'),
 	'yeelink.light.color1': require('./devices/yeelight.color'),
+	'philips.light.bulb': require('./devices/philips-light-bulb')
 
-	'philips.light.sread1': require('./devices/eyecare-lamp2'),
 };

--- a/lib/models.js
+++ b/lib/models.js
@@ -38,6 +38,7 @@ module.exports = {
 	'yeelink.light.lamp1': require('./devices/yeelight.lamp'),
 	'yeelink.light.mono1': require('./devices/yeelight.mono'),
 	'yeelink.light.color1': require('./devices/yeelight.color'),
+	'philips.light.sread1': require('./devices/eyecare-lamp2'),
 	'philips.light.bulb': require('./devices/philips-light-bulb')
-
+	
 };


### PR DESCRIPTION
Implements commands mentioned in #43 

Device doesn't seem to support auto-token so extracting the token e.g. from the Mi Home sqlite database is required 