### PR TITLE
fix bad voltage (empty value) for lumi.weather

### DIFF
--- a/lib/devices/gateway/voltage.js
+++ b/lib/devices/gateway/voltage.js
@@ -19,7 +19,7 @@ module.exports = Thing.mixin(Parent => class extends Parent.with(BatteryLevel) {
 
 	propertyUpdated(key, value, oldValue) {
 		if(key === 'voltage' && value) {
-			this.updateBatteryLevel((value - VOLTAGE_MIN) / (VOLTAGE_MAX - VOLTAGE_MIN) * 100);
+			this.updateBatteryLevel(Number((value - VOLTAGE_MIN) / (VOLTAGE_MAX - VOLTAGE_MIN) * 100).toFixed(2));
 		}
 
 		super.propertyUpdated(key, value, oldValue);

--- a/lib/devices/gateway/voltage.js
+++ b/lib/devices/gateway/voltage.js
@@ -18,7 +18,7 @@ module.exports = Thing.mixin(Parent => class extends Parent.with(BatteryLevel) {
 	}
 
 	propertyUpdated(key, value, oldValue) {
-		if(key === 'voltage') {
+		if(key === 'voltage' && value) {
 			this.updateBatteryLevel((value - VOLTAGE_MIN) / (VOLTAGE_MAX - VOLTAGE_MIN) * 100);
 		}
 


### PR DESCRIPTION
The voltage value is empty in the second message from my lumi.weather (result : negative incoherent value) 
`thing:miio:57541423 -> (5) {"method":"get_device_prop_exp","params":[["lumi.158d00022882d6","voltage","temperature","humidity","pressure"]],"id":9} +30ms
thing:miio:57541423 <- Message: ``{"result":[["",1110,4881,100570]],"id":9}`` +14ms`