### PR TITLE
New humidifier & Add activateZoneClean

### DIFF
--- a/lib/devices/vacuum.js
+++ b/lib/devices/vacuum.js
@@ -288,7 +288,8 @@ module.exports = class extends Vacuum.with(
 	 */
 	activateZoneClean(zones) {
 		return this.call('app_zoned_clean', zones, {
-			refresh: [ 'state' ]
+			refresh: [ 'state' ],
+			refreshDelay: 1000
 		})
 			.then(checkResult);
 	}

--- a/lib/devices/vacuum.js
+++ b/lib/devices/vacuum.js
@@ -278,6 +278,21 @@ module.exports = class extends Vacuum.with(
 			}));
 	}
 
+	/**
+	 * Start cleaning at specified zones.
+	 * Takes in an array of zones.
+	 * Zones example: [[26234,26042,26634,26642,1],[26232,25304,27282,25804,2],[26246,24189,27296,25139,2]]
+	 * Single zone example: [26234,26042,26634,26642,1]
+	 * Each zone contains an array of 5 values. top-left-x, top-left-y, bottom-right-x, bottom-right-y, number of clean times.
+	 * Maps are always 51200 x 51200. The charger/starting location is always the center; so 25600, 25600
+	 */
+	activateZoneClean(zones) {
+		return this.call('app_zoned_clean', zones, {
+			refresh: [ 'state' ]
+		})
+			.then(checkResult);
+	}
+
 	loadProperties(props) {
 		// We override loadProperties to use get_status and get_consumables
 		props = props.map(key => this._reversePropertyDefinitions[key] || key);

--- a/lib/models.js
+++ b/lib/models.js
@@ -34,6 +34,7 @@ module.exports = {
 	'zhimi.airpurifier.ma2': AirPurifier,
 
 	'zhimi.humidifier.v1': Humidifier,
+	'zhimi.humidifier.ca1': Humidifier,
 
 	'chuangmi.plug.m1': PowerPlug,
 	'chuangmi.plug.v1': require('./devices/chuangmi.plug.v1'),


### PR DESCRIPTION
### 1. Added new humidifier model.

`'zhimi.humidifier.ca1': Humidifier,`

### 2. Added activateZoneClean in vacuum.js

Takes in an array of zones.

**Zones example:** 
`[[26234,26042,26634,26642,1],[26232,25304,27282,25804,2],[26246,24189,27296,25139,2]]`

**Single zone example:** 
`[26234,26042,26634,26642,1]`

Each zone contains an array of 5 values. `top-left-x, top-left-y, bottom-right-x, bottom-right-y, number of clean times.`

Maps are always 51200 x 51200. The charger/starting location is always the centre; so` 25600, 25600`

**Tip on creating zones**

Despite not having the map data we can make zones by having the mi home app open, drawing a square to surround 25600,25600 (the starting location) it will show the zone we've set. We can find the coordinates of our desired zone through trial and error.

As long as the vacuum is started from the charging dock, it should always result in drawing the same map; and thus same zone coordinates. Although deviations can occur from moving the dock, or moving the vacuum by hand.