### PR TITLE
Fixed typo for filterWorkTime and sensorDirtyTime

### DIFF
--- a/lib/devices/vacuum.js
+++ b/lib/devices/vacuum.js
@@ -106,10 +106,10 @@ module.exports = class extends Vacuum.with(
 		this.defineProperty('side_brush_work_time', {
 			name: 'sideBrushWorkTime'
 		});
-		this.defineProperty('filterWorkTime', {
+		this.defineProperty('filter_work_time', {
 			name: 'filterWorkTime'
 		});
-		this.defineProperty('sensorDirtyTime', {
+		this.defineProperty('sensor_dirty_time', {
 			name: 'sensorDirtyTime'
 		});
 


### PR DESCRIPTION
Before

{ state: 'cleaning',
  batteryLevel: 78,
  cleanTime: 925,
  cleanArea: 17.05,
  fanSpeed: 38,
  in_cleaning: 0,
  mainBrushWorkTime: 363402,
  sideBrushWorkTime: 363402 },

Now:

{ state: 'cleaning',
  batteryLevel: 78,
  cleanTime: 925,
  cleanArea: 17.05,
  fanSpeed: 38,
  in_cleaning: 0,
  mainBrushWorkTime: 363402,
  sideBrushWorkTime: 363402,
  filterWorkTime: 363402,
  sensorDirtyTime: 248889 },