### PR TITLE
Fix for SSID and passwords starting with 0x

### DIFF
--- a/cli/commands/configure.js
+++ b/cli/commands/configure.js
@@ -10,12 +10,14 @@ exports.description = 'Control a device by invoking the given method';
 exports.builder = {
 	ssid: {
 		required: true,
-		description: 'SSID of the WiFi network'
+		description: 'SSID of the WiFi network',
+		type: 'string'
 	},
 
 	passwd: {
 		required: true,
-		description: 'Password of WiFi-network'
+		description: 'Password of WiFi-network',
+		type: 'string'
 	}
 };
 


### PR DESCRIPTION
By default string starting with `0x` are parsed as hexadecimal numbers by yargs.  
This fix allows to configure devices with an SSID starting with the string `0x`.