### PR TITLE
Plug devices: Properly set initial power state

### DIFF
--- a/lib/devices/capabilities/power.js
+++ b/lib/devices/capabilities/power.js
@@ -4,7 +4,7 @@ const { Thing, SwitchablePower } = require('abstract-things');
 
 module.exports = Thing.mixin(Parent => class extends Parent.with(SwitchablePower) {
 	propertyUpdated(key, value) {
-		if(key === 'power') {
+		if(key === 'power' && value !== undefined) {
 			this.updatePower(value);
 		}
 

--- a/lib/devices/gateway/plug.js
+++ b/lib/devices/gateway/plug.js
@@ -21,7 +21,7 @@ module.exports = class Plug extends SubDevice
 
 		this.defineProperty('status', {
 			name: 'power',
-			mapper: v => v === 'on'
+			mapper: v => (v === '') ? undefined : (v === 'on')
 		});
 
 		this.defineProperty('load_voltage', {


### PR DESCRIPTION
‘status’ can get a value of empty string (at least in the case of the
Zigbee gateway-based power plugs), which used to get translated to a
'false' power state. This would cause the triggering of the powerChanged
event twice on initialisation if the device was on already, with the
empty string case being the second call. This would cause users that monitor
the ‘powerChanged’ event to falsely report a power plug as off.

This fix explicitly allows for the empty string case, and avoids updating
the power state in this case.