### PR TITLE
Add 'zhimi.airpurifier.mc1' air purifier model

### DIFF
--- a/lib/models.js
+++ b/lib/models.js
@@ -32,6 +32,7 @@ module.exports = {
 
 	// Air Purifier 2S
 	'zhimi.airpurifier.ma2': AirPurifier,
+	'zhimi.airpurifier.mc1': AirPurifier,
 
 	'zhimi.humidifier.v1': Humidifier,
 


### PR DESCRIPTION
Some Air Purifier S2 models have this model name but apparently work fine otherwise.