### PR TITLE
Add zhimi.airpurifier.v7 support

### DIFF
--- a/lib/models.js
+++ b/lib/models.js
@@ -25,6 +25,7 @@ module.exports = {
 	'zhimi.airpurifier.v2': AirPurifier,
 	'zhimi.airpurifier.v3': AirPurifier,
 	'zhimi.airpurifier.v6': AirPurifier,
+	'zhimi.airpurifier.v7': AirPurifier,
 
 	// Air Purifier 2
 	'zhimi.airpurifier.m1': AirPurifier,


### PR DESCRIPTION
Some newer Air Purifier Pro devices have the following model ID: `zhimi.airpurifier.v7`

This is currently not supported by the library so I have created a PR to add it to the list of recognized air purifiers.