### PR TITLE
Don't call "miio.info" when a model was provided

### DIFF
--- a/lib/network.js
+++ b/lib/network.js
@@ -310,7 +310,7 @@ class DeviceInfo {
 			this.enriched = true;
 			this.tokenChanged = false;
 
-			this.enrichPromise = null;
+			return Promise.resolve()
 		}
 
 		return this.enrichPromise = promise

--- a/lib/network.js
+++ b/lib/network.js
@@ -305,6 +305,14 @@ class DeviceInfo {
 			promise = Promise.resolve();
 		}
 
+		// Check if a model was already provided
+		if (this.model) {
+			this.enriched = true;
+			this.tokenChanged = false;
+
+			this.enrichPromise = null;
+		}
+
 		return this.enrichPromise = promise
 			.then(() => this.call('miIO.info'))
 			.then(data => {


### PR DESCRIPTION
This fixes #162.

The issue was that when you use a rooted vacuum with disabled access to the xiaomi cloud, a call to `miio.info` would fail. This PR checks if a model was provided via the options parameter already and if it was, skips the info enrichment.

You can test if this fix works for you aswell by providing the model in your options:
`const device = await miio.device({ address: 'vacuum ip', token: 'vacuum token', model: 'rockrobo.vacuum.v1' })`