### PR TITLE
Magnet value fix

### DIFF
--- a/lib/devices/gateway/magnet.js
+++ b/lib/devices/gateway/magnet.js
@@ -18,7 +18,7 @@ module.exports = class Magnet extends SubDevice.with(Contact, Voltage) {
 	}
 
 	propertyUpdated(key, value, oldValue) {
-		if(key === 'status') {
+		if(key === 'status' && value !== null && typeof value !== 'undefined') {
 			// Change the contact state
 			const isContact = value === 'close';
 			this.updateContact(isContact);


### PR DESCRIPTION
There is an issue with the lumi.magnet initial value fetching in combination with the homebridge-miio-gateway and miio library. It returns the first value properly, but then triggers a second event where the value == null. This causes the the state to change to Open, when the actual state is Closed.

Fix: filter out null and undefined values.