### PR TITLE
Add model name for Xiaomi Roborock m1s Model

### DIFF
--- a/lib/models.js
+++ b/lib/models.js
@@ -41,6 +41,7 @@ module.exports = {
 
 	'rockrobo.vacuum.v1': Vacuum,
 	'roborock.vacuum.s5': Vacuum,
+	'roborock.vacuum.m1s': Vacuum,
 
 	'lumi.gateway.v2': Gateway.WithLightAndSensor,
 	'lumi.gateway.v3': Gateway.WithLightAndSensor,


### PR DESCRIPTION
other api is same. it works great.

i tested it, at my home.



=== miio inspect log
INFO Attempting to inspect [MYVACUUMIP]
Device ID: 260917297
Model info: roborock.vacuum.m1s
Address: [MYVACUUMIP]
Token: [MY_TOKEN] via stored token
Support: At least basic
Type info: miio:vacuum, miio, vaccuum
Capabilities: adjustable-fan-speed, fan-speed, spot-cleaning, autonomous-cleaning, cleaning-state, error-state, charging-state, battery-level, state
Firmware version: 3.4.5_0848
Hardware version: Linux
WiFi: sookigom_2g (B4:A9:4F:0F:D6:2E) RSSI: -42
Remote access (Mi Home App): Maybe
Properties:
state: charging
batteryLevel: 100
cleanTime: 1
cleanArea: 0
fanSpeed: 101
in_cleaning: 0
mainBrushWorkTime: 7713
sideBrushWorkTime: 7713
