### PR TITLE
Added Aqara Cube support

### DIFF
--- a/lib/devices/gateway/cube.js
+++ b/lib/devices/gateway/cube.js
@@ -10,7 +10,7 @@ const { Controller, Actions } = require('abstract-things/controllers');
  * Supports the actions:
  * * `alert` - when the cube has been idle for a while and it wakes up
  * * `flip90` - when the cube is flipped 90 degrees in any direction
- * * `flip180` - when the cube is flipped 180 degress in any direction
+ * * `flip180` - when the cube is flipped 180 degrees in any direction
  * * `move` - when the cube is moved on its current surface (slide)
  * * `shake_air` - when the cube is shaken in the air
  * * `free_fall` - when the cube is dropped in a free fall

--- a/lib/devices/gateway/subdevices.js
+++ b/lib/devices/gateway/subdevices.js
@@ -33,5 +33,7 @@ module.exports = {
 	// AQ2 motion sensor
 	52: require('./motion2'),
 	// AQ2 manget sensor
-	53: require('./magnet2')
+	53: require('./magnet2'),
+	// Aqara Cube controller
+	68: require('./cube')
 };


### PR DESCRIPTION
Aqara Cube has a device type id `68`.
Used the same code as for Mi Cube (device type id `8`)