### PR TITLE
Added European model Air Purifier 2H

### DIFF
--- a/lib/models.js
+++ b/lib/models.js
@@ -32,6 +32,9 @@ module.exports = {
 
 	// Air Purifier 2S
 	'zhimi.airpurifier.ma2': AirPurifier,
+	
+	// Air Purifier 2H
+	'zhimi.airpurifier.mc2': AirPurifier,
 
 	'zhimi.humidifier.v1': Humidifier,
 


### PR DESCRIPTION
PR to add model 2H.
Model seems to have the same capabilities as other models.
The only difference I see is that it doesn't have an RFID reader that recognizes the filter and is used for monitoring the filter's used time.